### PR TITLE
prov/gni: remove unnecessary mr code

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -271,8 +271,7 @@ static struct fi_info *_gnix_allocinfo(void)
 
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
-	gnix_info->domain_attr->mr_mode = FI_MR_BASIC | FI_MR_SCALABLE |
-					  OFI_MR_BASIC_MAP;
+	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
 	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	gnix_info->domain_attr->max_ep_tx_ctx = GNIX_SEP_MAX_CNT;
@@ -443,37 +442,6 @@ err:
 	return ret;
 }
 
-static inline int __gnix_check_mr_mode(int mr_mode)
-{
-	if (mr_mode & FI_MR_VIRT_ADDR) {
-		if ((mr_mode & ~GNIX_MR_BASIC_BITS) ||
-				((mr_mode & GNIX_MR_BASIC_REQ) !=
-					GNIX_MR_BASIC_REQ)) {
-			GNIX_DEBUG(FI_LOG_FABRIC,
-				"mr mode contains unsupported bits, "
-				"actual=%x supported=%x\n",
-				mr_mode, GNIX_MR_BASIC_BITS);
-		return 1;
-		}
-	} else if (mr_mode != FI_MR_BASIC &&
-			mr_mode != FI_MR_SCALABLE) {
-		/* FI_MR_SCALABLE for GNI */
-		if ((mr_mode & ~GNIX_MR_SCALABLE_BITS) ||
-				((mr_mode & GNIX_MR_SCALABLE_REQ) !=
-					GNIX_MR_SCALABLE_REQ)) {
-			GNIX_DEBUG(FI_LOG_FABRIC,
-				"mr mode contains unsupported bits, "
-				"actual=%x supported=%x\n",
-				mr_mode, GNIX_MR_SCALABLE_BITS);
-		return 1;
-		}
-	} else if (mr_mode == FI_MR_SCALABLE) {
-		GNIX_DEBUG(FI_LOG_FABRIC, "no support for the original enums");
-		return 1;
-	}
-	return 0;
-}
-
 static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 			    const char *node, const char *service,
 			    uint64_t flags, const struct fi_info *hints,
@@ -613,10 +581,16 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				gnix_info->domain_attr->data_progress =
 					hints->domain_attr->data_progress;
 
+			/* If basic registration isn't being requested,
+			   require FI_MR_MMU_NOTIFY */
+			if (!(hints->domain_attr->mr_mode &
+					(FI_MR_BASIC | FI_MR_ALLOCATED)))
+				gnix_info->domain_attr->mr_mode |= FI_MR_MMU_NOTIFY;
+
 			if (ofi_check_mr_mode(&gnix_prov, version,
 					gnix_info->domain_attr->mr_mode,
 					hints) != FI_SUCCESS) {
-				GNIX_DEBUG(FI_LOG_DOMAIN,
+				GNIX_INFO(FI_LOG_DOMAIN,
 					"failed ofi_check_mr_mode, "
 					"ret=%d\n", ret);
 				goto err;
@@ -635,11 +609,6 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 					goto err;
 				}
 			} else {
-				/* FIXME: Check will not work with ofi_check_mr_mode
-				if (__gnix_check_mr_mode(mr_mode))
-					goto err;
-				*/
-
 				/* define the mode we return to the user
 				 * prefer basic until scalable
 				 * has more testing time */
@@ -683,15 +652,6 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 		goto err;
 
 	ofi_alter_info(gnix_info, hints, version);
-
-	ret = ofi_check_domain_attr(&gnix_prov, version,
-				    gnix_info->domain_attr,
-				    gnix_info);
-	if (ret) {
-		GNIX_WARN(FI_LOG_FABRIC,
-				  "GNI failed domain attributes check\n");
-		goto err;
-	}
 
 	GNIX_DEBUG(FI_LOG_FABRIC, "Passed the domain attributes check\n");
 

--- a/prov/gni/test/fabric.c
+++ b/prov/gni/test/fabric.c
@@ -77,7 +77,7 @@ static void teardown(void)
 
 	fi_freeinfo(fi);
 }
-
+TestSuite(fabric_bare);
 TestSuite(fabric, .init = setup, .fini = teardown);
 
 Test(fabric, simple)
@@ -260,4 +260,120 @@ Test(fabric, set_limits)
 		&actual_attr.prov_key_limit);
 	cr_assert_eq(ret, FI_SUCCESS);
 	cr_assert_eq(actual_attr.prov_key_limit, expected_attr.prov_key_limit);
+}
+
+Test(fabric_bare, fi_mr_basic_1_0)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &info);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+	cr_assert(info->domain_attr->mr_mode == FI_MR_BASIC);
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+}
+
+Test(fabric_bare, fi_mr_scalable_1_0)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = FI_MR_SCALABLE;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &info);
+	cr_assert(ret == -FI_ENODATA, "fi_getinfo");
+
+	fi_freeinfo(hints);
+}
+
+Test(fabric_bare, fi_mr_basic_1_5)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 5), NULL, 0, 0, hints, &info);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+	cr_assert(info->domain_attr->mr_mode == FI_MR_BASIC);
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+}
+
+Test(fabric_bare, fi_mr_scalable_1_5_fail)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = FI_MR_SCALABLE;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 5), NULL, 0, 0, hints, &info);
+	cr_assert(ret == -FI_ENODATA, "fi_getinfo");
+
+	fi_freeinfo(hints);
+}
+
+Test(fabric_bare, fi_mr_scalable_1_5_pass)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = FI_MR_MMU_NOTIFY;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 5), NULL, 0, 0, hints, &info);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+	cr_assert(info->domain_attr->mr_mode == FI_MR_MMU_NOTIFY);
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
+}
+
+Test(fabric_bare, fi_mr_basic_1_5_ofi_map)
+{
+	int ret;
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = OFI_MR_BASIC_MAP;
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 5), NULL, 0, 0, hints, &info);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+	cr_assert(info->domain_attr->mr_mode == OFI_MR_BASIC_MAP);
+
+	fi_freeinfo(fi);
+	fi_freeinfo(hints);
 }


### PR DESCRIPTION
This commit removes the gni specific checks for memory
registration modes. In addition to that, it adds
unit tests to the gnitest suite to check for
expected results.

Signed-off-by: James Swaro <jswaro@cray.com>