### PR TITLE
prov/sockets: simplify listen paths

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -303,7 +303,8 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 	}
 
 	addr_size = sizeof(pep->src_addr);
-	if (!ofi_getsockname(pep->cm.sock, &pep->src_addr.sa, &addr_size)) {
+	if (ofi_getsockname(pep->cm.sock, &pep->src_addr.sa,
+			    &addr_size) == SOCKET_ERROR) {
 		ret = -ofi_sockerr();
 		goto err;
 	}


### PR DESCRIPTION
Remove unnecessary calls to convert socket addresses into
strings and back again.

Sean, this is your commit but with fixed bug that I mentioned in your PR against the master branch 
 of the ofiwg/libfabric repo.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>